### PR TITLE
use public ECR rather than dockerhub for ubuntu image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -21,7 +21,7 @@ resources:
   - name: docker-hub-image
     type: registry-image
     source:
-      repository: ubuntu
+      repository: public.ecr.aws/lts/ubuntu
       tag: "22.04"
 
   - name: ecr-image


### PR DESCRIPTION
## Changes proposed in this pull request:

- Updates the pipeline to grab the public ubuntu image from ECR rather than Dockerhub
- I compared the images and they are exactly the same

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Downloads ubuntu image from public ECR rather than Dockerhub
